### PR TITLE
remove deprecated jac func "to_py"

### DIFF
--- a/pyNeuralEMPC/model/jax.py
+++ b/pyNeuralEMPC/model/jax.py
@@ -58,7 +58,7 @@ class DiffDiscretJaxModel(Model):
             jacobians[0] = jacobians[0].reshape(self.x_dim*x.shape[0], self.x_dim*x.shape[0] )
             jacobians[1] = jacobians[1].reshape(self.x_dim*x.shape[0], self.u_dim*x.shape[0] )
 
-            jaco =  jnp.concatenate(jacobians, axis=1).to_py()
+            jaco =  np.array(jnp.concatenate(jacobians, axis=1))
             return jaco
         else:
             raise NotImplementedError("")
@@ -83,7 +83,7 @@ class DiffDiscretJaxModel(Model):
 
             final_hessian = jnp.concatenate([ab, cd], axis=2)
 
-            return final_hessian.to_py()
+            return np.array(final_hessian)
         else:
             raise NotImplementedError("")
 

--- a/pyNeuralEMPC/objective/jax.py
+++ b/pyNeuralEMPC/objective/jax.py
@@ -36,9 +36,9 @@ class JAXObjectifFunc(ObjectiveFunc):
         grad_u = jax.grad(self.func, argnums=1)(states, u, p, tvp).reshape(-1)
 
         result_list = [grad_states, grad_u]
-        final_res = jnp.concatenate(result_list, axis=0).to_py()
+        final_res = jnp.concatenate(result_list, axis=0)
         final_res = jnp.nan_to_num(final_res, nan=0.0)
-        return final_res
+        return np.array(final_res)
 
     def hessian(self, states, u, p=None, tvp=None):
 


### PR DESCRIPTION
Remove a deprecated function since jax 0.3.7